### PR TITLE
Revert "Create portable.h"

### DIFF
--- a/VIAFreeRTOSTest/portable.h
+++ b/VIAFreeRTOSTest/portable.h
@@ -1,5 +1,0 @@
-#pragma once
-#include "FreeRTOS.h"
-
-void* pvPortMalloc(size_t xSize);
-void vPortFree(void*);


### PR DESCRIPTION
Reverts ihavn/GoogleTestDemo#1

It throws a "SEH exception with code 0xc0000005 thrown in the test body"
when using this mockup in a test, no fix found yet.