### PR TITLE
Revert "Update FreeRTOS_FFF_MocksDefinitions.cpp"

### DIFF
--- a/VIAFreeRTOSTest/FreeRTOS_FFF_MocksDefinitions.cpp
+++ b/VIAFreeRTOSTest/FreeRTOS_FFF_MocksDefinitions.cpp
@@ -145,7 +145,3 @@ DEFINE_FAKE_VALUE_FUNC(TickType_t, xTimerGetPeriod, TimerHandle_t);
 DEFINE_FAKE_VALUE_FUNC(TickType_t, xTimerGetExpiryTime, TimerHandle_t);
 // UBaseType_t uxTimerGetReloadMode(TimerHandle_t xTimer);
 DEFINE_FAKE_VALUE_FUNC(UBaseType_t, uxTimerGetReloadMode, TimerHandle_t);
-
-//portable.h
-DEFINE_FAKE_VALUE_FUNC(void*, pvPortMalloc, size_t);
-DEFINE_FAKE_VOID_FUNC(vPortFree, void*)


### PR DESCRIPTION
Reverts ihavn/GoogleTestDemo#3

It throws a "SEH exception with code 0xc0000005 thrown in the test body"
when using this mockup in a test, no fix found yet